### PR TITLE
Download files rather than zips

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python: Current File",
+      "type": "python",
+      "request": "launch",
+      "program": "${file}",
+      "console": "integratedTerminal",
+      "justMyCode": true,
+      "envFile": "${workspaceFolder}/.env",
+      "args":[
+        "--per-page",
+        "20",
+        "--start-page",
+        "14",
+        "--pages",
+        "1"
+      ]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ tedious 🤦 limitation enforced by GoPro Media Library website.**
 
 ## Usage (Docker environment)
 * `docker pull itsankoff/gopro`
-* `docker run -e AUTH_TOKEN=<gopro-auth_token> itsankoff/gopro`
+* `docker run -e AUTH_TOKEN=<gopro-auth_token> --mount type=bind,src="`pwd`/download",target=/app/download itsankoff/gopro`
 
 Supported Docker ENV variable options:
 * `-e AUTH_TOKEN=<gopro-auth-token>` - (**required**) authentication token
         obtained from GoPro Media Library website. See [setup guide](#setting-up-auth_token-as-environment-variable).
-* `-e ACTION=<list|download>` - (*optional*) action to execute. The default is `download`.
+* `-e ACTION=<list|download|download-upload>` - (*optional*) action to execute. The default is `download`.
 * `-e START_PAGE=<number>` - (*optional*) run the `<action>` from specific page
         (GoPro Media Library API is paginated). The default `1`.
 * `-e PAGES=<number>` - (*optional*) run the `<action>` over the specified number of pages.
@@ -97,3 +97,15 @@ $env:AUTH_TOKEN="<gibberish_string_here>"
 Once the AUTH_TOKEN is set, you can run the GoPro Plus application without needing to pass the token explicitly.
 Remember to replace `<gibberish_string_here>` with the actual token you copied from the console.
 By following these steps, you should be able to effectively manage your GoPro Plus media directly from your command line using GoPro Plus.
+
+## S3 upload
+When setting `action=download-upload`, the app will upload the files to S3 immediately and delete the local file after upload completes.  
+
+You will need to provide additional environment variables for AWS credentials and S3.  
+
+```
+export S3_ENDPOINT_URL="s3.us-west-2.amazonaws.com"
+export AWS_ACCESS_KEY_ID="xxxxxxxxx"
+export AWS_SECRET_ACCESS_KEY="xxxxxxxxxxxxxxxxx"
+export S3_BUCKET_NAME="MyS3Bucket"
+```

--- a/main.py
+++ b/main.py
@@ -127,7 +127,7 @@ class GoProPlus:
         return output_media
 
 
-    def download_media_ids(self, ids, filepath, progress_mode="inline", action="download"):
+    def download_media_ids(self, ids, filepath, action="download", progress_mode="inline"):
         # for each id we need to make a request to get the download url
         results = []
 
@@ -178,8 +178,13 @@ class GoProPlus:
                             # Calculate the progress percentage
                             percentage = int(downloaded_size * 100 / total_size)
 
-                            # Display the download progress on the screen
-                            print(f'Downloading {file_name}: {percentage}%')
+                            if progress_mode == "inline":
+                              # Display the download progress on the screen
+                              print(f'\rDownloading {file_name}: {percentage}%', end='')
+
+                            if progress_mode == "newline":
+                              # Display the download progress on the screen
+                              print(f'Downloading {file_name}: {percentage}%')
 
                     # Close the response object
                     r.close()
@@ -204,6 +209,7 @@ class GoProPlus:
                               )
                       
                       # Delete local file
+                      print(f"\n")
                       print(f'Deleting local file: {file_path}')
                       os.remove(file_path)
 
@@ -257,7 +263,7 @@ def main():
         if args.action.startswith("download"):
             filepath = "{}".format(args.download_path)
             ids = gpp.get_ids_from_media(media)
-            gpp.download_media_ids(ids, filepath, progress_mode=args.progress_mode, args.action)
+            gpp.download_media_ids(ids, filepath, args.action, progress_mode=args.progress_mode)
 
 
 if __name__ == "__main__":

--- a/main.py
+++ b/main.py
@@ -82,13 +82,13 @@ class GoProPlus:
         return err
     
     def get_ids_and_dates_from_media(self, media):
-        return [{"id": x["id"], "created_at": x["created_at"]} for x in media]
+        return [{"id": x["id"], "captured_at": x["captured_at"]} for x in media]
 
-    def get_createdats_from_media(self, media):
-        return [x["created_at"] for x in media]
+    def get_capturedats_from_media(self, media):
+        return [x["captured_at"] for x in media]
 
-    def get_filenames_and_createdats_from_media(self, media):
-        return [{"filename": x["filename"], "created_at": x["created_at"]} for x in media]
+    def get_filenames_and_capturedats_from_media(self, media):
+        return [{"filename": x["filename"], "captured_at": x["captured_at"]} for x in media]
 
     def get_media(self, start_page=1, pages=sys.maxsize, per_page=30):
         media_url = "{}/media/search".format(self.host)
@@ -109,7 +109,7 @@ class GoProPlus:
         while True:
             params = {
                 # for all fields check some requests on GoProPlus website requests
-                "fields": "id,created_at,content_title,filename,file_extension",
+                "fields": "id,captured_at,content_title,filename,file_extension",
                 "per_page": per_page,
                 "page": current_page,
                 "type": "",
@@ -216,14 +216,14 @@ class GoProPlus:
                       # Display on the screen that the download was successfully completed
                       print(f'\n{file_name} download successful!')
 
-                      # Set the created_date of the file with item['created_at']
-                      created_date = item['created_at']
+                      # Set the captured_date of the file with item['captured_at']
+                      captured_date = item['captured_at']
 
                       # Parse the date string to a datetime object
-                      created_date = parse(created_date)
+                      captured_date = parse(captured_date)
 
                       # Convert the datetime object to a timestamp
-                      timestamp = created_date.timestamp()
+                      timestamp = captured_date.timestamp()
 
                       # Set the access time and the modification time
                       os.utime(file_path, (timestamp, timestamp))
@@ -299,9 +299,9 @@ def main():
         return -1
 
     for page, media in media_pages.items():
-        fileswithdates = gpp.get_filenames_and_createdats_from_media(media)
+        fileswithdates = gpp.get_filenames_and_capturedats_from_media(media)
         for filewithdate in fileswithdates:
-          print("listing page({}) filename({}) date({})".format(page, filewithdate["filename"], filewithdate["created_at"]))
+          print("listing page({}) filename({}) date({})".format(page, filewithdate["filename"], filewithdate["captured_at"]))
 
 
         if args.action.startswith("download"):

--- a/main.py
+++ b/main.py
@@ -12,12 +12,13 @@ import boto3.session
 
 from boto3.s3.transfer import TransferConfig
 
-transfer_config = TransferConfig(multipart_threshold=1024 * 25, 
-                        max_concurrency=10,
-                        multipart_chunksize=1024 * 25,
-                        use_threads=True)
+transfer_config = TransferConfig(multipart_threshold=1024 * 25,
+                                 max_concurrency=10,
+                                 multipart_chunksize=1024 * 25,
+                                 use_threads=True)
 
 sys.stdout = open(1, "w", encoding="utf-8", closefd=False)
+
 
 def handler(signum, frame):
     print("\ninterrupting the process. do you really want to exit? (y/n) ")
@@ -29,26 +30,29 @@ def handler(signum, frame):
     else:
         print("continue executing...")
 
+
 signal.signal(signal.SIGINT, handler)
 
-class ProgressPercentage(object):
-        def __init__(self, filename):
-            self._filename = filename
-            self._size = float(os.path.getsize(filename))
-            self._seen_so_far = 0
-            self._lock = threading.Lock()
 
-        def __call__(self, bytes_amount):
-            # To simplify we'll assume this is hooked up
-            # to a single filename.
-            with self._lock:
-                self._seen_so_far += bytes_amount
-                percentage = (self._seen_so_far / self._size) * 100
-                sys.stdout.write(
-                    "\r%s  %s / %s  (%.2f%%)" % (
-                        self._filename, self._seen_so_far, self._size,
-                        percentage))
-                sys.stdout.flush()
+class ProgressPercentage(object):
+    def __init__(self, filename):
+        self._filename = filename
+        self._size = float(os.path.getsize(filename))
+        self._seen_so_far = 0
+        self._lock = threading.Lock()
+
+    def __call__(self, bytes_amount):
+        # To simplify we'll assume this is hooked up
+        # to a single filename.
+        with self._lock:
+            self._seen_so_far += bytes_amount
+            percentage = (self._seen_so_far / self._size) * 100
+            sys.stdout.write(
+                "\r%s  %s / %s  (%.2f%%)" % (
+                    self._filename, self._seen_so_far, self._size,
+                    percentage))
+            sys.stdout.flush()
+
 
 class GoProPlus:
     def __init__(self, auth_token):
@@ -126,8 +130,7 @@ class GoProPlus:
 
         return output_media
 
-
-    def download_media_ids(self, ids, filepath, action="download", progress_mode="inline"):
+    def download_media_ids(self, ids, filepath, action="download", progress_mode="inline", resolution="source"):
         # for each id we need to make a request to get the download url
         results = []
 
@@ -143,102 +146,127 @@ class GoProPlus:
             }
 
             resp = requests.get(url, params=params, headers=headers).json()
-            file_url = resp['_embedded']['files'][0]['url']
-            file_name = file_url.split('/')[-1]
-            file_name = resp['filename']
 
+            file_url = None
+            if resolution == "1080p":
+                file_url = resp['_embedded']['files'][0]['url']
+            if resolution == "source":
+                # Extract the URL for the label=source item under variations
+                for variation in resp['_embedded']['variations']:
+                    if variation['label'] == 'source':
+                        file_url = variation['url']
+                        break
+            else:
+                print(f'Invalid resolution. {resolution} not found')
+
+            file_name = resp['filename']
             file_path = os.path.join(filepath, file_name)
 
-            # Try to download the file using streaming
-            try:
-                # Create a response object with streaming enabled
-                r = requests.get(file_url, stream=True)
+            # See if file exists:
+            if os.path.exists(file_path):
+                print(f'{file_name} already exists. skipping...')
+                results.append({'id': id, 'status': 'skipped', 'file': file_path})
+                continue
+            else:
+                # Try to download the file using streaming
+                try:
+                    # Create a response object with streaming enabled
+                    r = requests.get(file_url, stream=True)
 
-                # Check if the response status code is 200 (OK)
-                if r.status_code == 200:
-                    # Open the file in binary write mode
-                    with open(file_path, 'wb') as f:
-                        # Define the chunk size in bytes
-                        piece_size = 1024 * 1024
+                    # Check if the response status code is 200 (OK)
+                    if r.status_code == 200:
+                        # Open the file in binary write mode
+                        with open(file_path, 'wb') as f:
+                            # Define the chunk size in bytes
+                            piece_size = 1024 * 1024
 
-                        # Get the total file size in bytes from the response header
-                        total_size = int(r.headers.get('content-length', 0))
+                            # Get the total file size in bytes from the response header
+                            total_size = int(r.headers.get('content-length', 0))
 
-                        # Initialize a variable to store the downloaded size in bytes
-                        downloaded_size = 0
+                            # Initialize a variable to store the downloaded size in bytes
+                            downloaded_size = 0
 
-                        # Traverse the chunks of the response
-                        for chunk in r.iter_content(piece_size):
-                            # Write the chunk to the file
-                            f.write(chunk)
+                            # Traverse the chunks of the response
+                            for chunk in r.iter_content(piece_size):
+                                # Write the chunk to the file
+                                f.write(chunk)
 
-                            # Increase the downloaded size by the size of the chunk
-                            downloaded_size += len(chunk)
+                                # Increase the downloaded size by the size of the chunk
+                                downloaded_size += len(chunk)
 
-                            # Calculate the progress percentage
-                            percentage = int(downloaded_size * 100 / total_size)
+                                # Calculate the progress percentage
+                                percentage = int(downloaded_size * 100 / total_size)
 
-                            if progress_mode == "inline":
-                              # Display the download progress on the screen
-                              print(f'\rDownloading {file_name}: {percentage}%', end='')
+                                if progress_mode == "inline":
+                                    # Display the download progress on the screen
+                                    print(f'\rDownloading {file_name}: {percentage}%', end='')
 
-                            if progress_mode == "newline":
-                              # Display the download progress on the screen
-                              print(f'Downloading {file_name}: {percentage}%')
+                                if progress_mode == "newline":
+                                    # Display the download progress on the screen
+                                    print(f'Downloading {file_name}: {percentage}%')
 
-                    # Close the response object
-                    r.close()
+                        # Close the response object
+                        r.close()
 
-                    # Display on the screen that the download was successfully completed
-                    print(f'{file_name} download successful!')
+                        # Display on the screen that the download was successfully completed
+                        print(f'{file_name} download successful!')
 
-                    # Add a result with a success status to the results list
-                    results.append({'id': id, 'status': 'sucesso', 'file': file_path})
+                        # Add a result with a success status to the results list
+                        results.append({'id': id, 'status': 'sucesso', 'file': file_path})
 
-                    # upload to s3
-                    if action == 'download-upload':
-                      print(f'Uploading: {file_path} to {os.environ["S3_BUCKET_NAME"]}')
-                      S3_ENDPOINT_URL = "https://" + os.environ["S3_ENDPOINT_URL"]
-                      b2session = boto3.session.Session(aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"], aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"])
-                      b2 = b2session.resource(service_name='s3', endpoint_url=S3_ENDPOINT_URL)
-                      
-                      b2.Object(os.environ["S3_BUCKET_NAME"], file_name).upload_file(file_path,
-                              ExtraArgs={'ContentType': 'text/pdf'},
-                              Config=transfer_config,
-                              Callback=ProgressPercentage(file_path)
-                              )
-                      
-                      # Delete local file
-                      print(f"\n")
-                      print(f'Deleting local file: {file_path}')
-                      os.remove(file_path)
+                        # upload to s3
+                        if action == 'download-upload':
+                            print(f'Uploading: {file_path} to {os.environ["S3_BUCKET_NAME"]}')
+                            S3_ENDPOINT_URL = "https://" + os.environ["S3_ENDPOINT_URL"]
+                            b2session = boto3.session.Session(aws_access_key_id=os.environ["AWS_ACCESS_KEY_ID"],
+                                                              aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"])
+                            b2 = b2session.resource(service_name='s3', endpoint_url=S3_ENDPOINT_URL)
 
-                else:
-                    # Display on the screen that the download failed due to the status code
-                    print(f'{file_name} could not be downloaded: status code {r.status_code}')
+                            b2.Object(os.environ["S3_BUCKET_NAME"], file_name).upload_file(file_path,
+                                                                                           ExtraArgs={
+                                                                                               'ContentType': 'text/pdf'},
+                                                                                           Config=transfer_config,
+                                                                                           Callback=ProgressPercentage(
+                                                                                               file_path)
+                                                                                           )
+
+                            # Delete local file
+                            print(f"\n")
+                            print(f'Deleting local file: {file_path}')
+                            os.remove(file_path)
+
+                    else:
+                        # Display on the screen that the download failed due to the status code
+                        print(f'{file_name} could not be downloaded: status code {r.status_code}')
+
+                        # Add a result with an error status to the results list
+                        results.append({'id': id, 'status': 'erro', 'reason': f'status code {r.status_code}'})
+
+                except Exception as e:
+                    # Display on the screen that the download failed due to an exception
+                    print(f'{file_name} could not be downloaded: {e}')
 
                     # Add a result with an error status to the results list
-                    results.append({'id': id, 'status': 'erro', 'reason': f'código de status {r.status_code}'})
-
-            except Exception as e:
-                # Display on the screen that the download failed due to an exception
-                print(f'{file_name} could not be downloaded: {e}')
-
-                # Add a result with an error status to the results list
-                results.append({'id': id, 'status': 'erro', 'reason': str(e)})
+                    results.append({'id': id, 'status': 'error', 'reason': str(e)})
 
 
 def main():
     actions = ["list", "download"]
     progress_modes = ["inline", "newline", "noline"]
+    resolutions = ["1080p", "source"]
 
     parser = argparse.ArgumentParser(prog="gopro")
-    parser.add_argument("--action", help="action to execute. supported actions: {}".format(",".join(actions)), default="download")
+    parser.add_argument("--action", help="action to execute. supported actions: {}".format(",".join(actions)),
+                        default="download")
     parser.add_argument("--pages", nargs="?", help="number of pages to iterate over", type=int, default=sys.maxsize)
     parser.add_argument("--per-page", nargs="?", help="number of items per page", type=int, default=30)
     parser.add_argument("--start-page", nargs="?", help="starting page", type=int, default=1)
     parser.add_argument("--download-path", help="path to store the download zip", default="./download")
-    parser.add_argument("--progress-mode", help="showing download progress. supported modes: {}".format(",".join(progress_modes)), default=progress_modes[0])
+    parser.add_argument("--progress-mode",
+                        help="showing download progress. supported modes: {}".format(",".join(progress_modes)),
+                        default=progress_modes[0])
+    parser.add_argument("--resolution", help="resolution to download, use: {}".format(",".join(resolutions)),
+                        default=resolutions[1])
 
     args = parser.parse_args()
 
@@ -263,7 +291,8 @@ def main():
         if args.action.startswith("download"):
             filepath = "{}".format(args.download_path)
             ids = gpp.get_ids_from_media(media)
-            gpp.download_media_ids(ids, filepath, args.action, progress_mode=args.progress_mode)
+            gpp.download_media_ids(ids, filepath, args.action, progress_mode=args.progress_mode,
+                                   resolution=args.resolution)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ idna==3.4
 readchar==4.0.5
 requests==2.31.0
 urllib3==2.0.6
+boto3==1.34.16


### PR DESCRIPTION
This change will cause the app to download the files directly, rather than downloading zip archives. I was experiencing a bug in `api.gopro.com` where video files were not included in the zip archive. For this reason, I decided it's better to just download each media file individually. The zip compression wasn't doing much for us anyway, as the files were already compressed. 

I also added an option to upload the files to S3 as they are downloaded by using `--action download-upload`. There are additional environment variables needed for this, as documented in the README file.

These changes are based on what I found [here](https://gist.github.com/Rehzende/660e6a4933d0a6e52f843a6f447553aa).

This worked well for me to extract all my media from GoPro plus and upload it to BackBlaze. The GoPro api was flakey on downloading files. I used the `--action list` to produce a list of pages with each media file. When there was a failure, I would look at what page the media file was on at the time of failure and restart the process using `--start-page <page>`, passing in the appropriate start page.

This changes also sets the file created date to the captured date value from GoPro media metadata.
